### PR TITLE
Fix env handling for Azure training job

### DIFF
--- a/submit_jobCog.py
+++ b/submit_jobCog.py
@@ -56,6 +56,8 @@ job = command(
     code="/home/azureuser/cloudfiles/code/Users/dieter.holstein/runs/HuggingFace/CogKitFix",
     command="""
         export CODE_DIR=$(pwd)
+        export MODEL_PATH=${{inputs.pretrained_model}}
+        export DATA_ROOT=${{inputs.train_data}}
         export OUTPUT_DIR=$CODE_DIR/output
         mkdir -p "$OUTPUT_DIR"
 
@@ -76,9 +78,6 @@ job = command(
     experiment_name="dieter_CogVideo_Training",
     display_name="train_CogVideo_lora_job",
     environment_variables={
-        "MODEL_PATH": "${{inputs.pretrained_model}}",
-        "DATA_ROOT":  "${{inputs.train_data}}",
-        "OUTPUT_DIR": "/workspace_placeholder",  # wird gleich ersetzt
         "BNB_CUDA_VERSION": "124",
     },
 )


### PR DESCRIPTION
## Summary
- correctly export dataset locations before running training

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cogkit')*

------
https://chatgpt.com/codex/tasks/task_e_6862dfd81994832b94300a126635aaa1